### PR TITLE
kernel: add patch against dirty pipe

### DIFF
--- a/recipes-kernel/linux/linux-karo-5.10/patches/0001-lib-iov_iter-initialize-flags-in-new-pipe_buffer.patch
+++ b/recipes-kernel/linux/linux-karo-5.10/patches/0001-lib-iov_iter-initialize-flags-in-new-pipe_buffer.patch
@@ -1,0 +1,43 @@
+From 9d2231c5d74e13b2a0546fee6737ee4446017903 Mon Sep 17 00:00:00 2001
+From: Max Kellermann <max.kellermann@ionos.com>
+Date: Mon, 21 Feb 2022 11:03:13 +0100
+Subject: [PATCH] lib/iov_iter: initialize "flags" in new pipe_buffer
+
+The functions copy_page_to_iter_pipe() and push_pipe() can both
+allocate a new pipe_buffer, but the "flags" member initializer is
+missing.
+
+Fixes: 241699cd72a8 ("new iov_iter flavour: pipe-backed")
+To: Alexander Viro <viro@zeniv.linux.org.uk>
+To: linux-fsdevel@vger.kernel.org
+To: linux-kernel@vger.kernel.org
+Cc: stable@vger.kernel.org
+Signed-off-by: Max Kellermann <max.kellermann@ionos.com>
+Signed-off-by: Al Viro <viro@zeniv.linux.org.uk>
+---
+ lib/iov_iter.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/iov_iter.c b/lib/iov_iter.c
+index b0e0acdf96c1..6dd5330f7a99 100644
+--- a/lib/iov_iter.c
++++ b/lib/iov_iter.c
+@@ -414,6 +414,7 @@ static size_t copy_page_to_iter_pipe(struct page *page, size_t offset, size_t by
+ 		return 0;
+ 
+ 	buf->ops = &page_cache_pipe_buf_ops;
++	buf->flags = 0;
+ 	get_page(page);
+ 	buf->page = page;
+ 	buf->offset = offset;
+@@ -577,6 +578,7 @@ static size_t push_pipe(struct iov_iter *i, size_t size,
+ 			break;
+ 
+ 		buf->ops = &default_pipe_buf_ops;
++		buf->flags = 0;
+ 		buf->page = page;
+ 		buf->offset = 0;
+ 		buf->len = min_t(ssize_t, left, PAGE_SIZE);
+-- 
+2.34.1
+

--- a/recipes-kernel/linux/linux-karo_5.10.bb
+++ b/recipes-kernel/linux/linux-karo_5.10.bb
@@ -28,6 +28,7 @@ SRC_URI_append = " \
 	file://0016-parallel-display-bus-flags-from-display-info.patch \
 	file://0017-spi-nand-dma-map-bugfix.patch \
 	file://0019-fdt5x06-dma-bugfix.patch \
+        file://0001-lib-iov_iter-initialize-flags-in-new-pipe_buffer.patch \
 "
 
 SRC_URI_append_tx6 = " \


### PR DESCRIPTION
https://dirtypipe.cm4all.com/
https://www.heise.de/news/Linux-Dirty-Pipe-beschert-Root-Rechte-6541556.html