### PR TITLE
linux: stm32mp1: dts: txmp: Remove st,use-ckin property from sdmmc3

### DIFF
--- a/recipes-kernel/linux/linux-karo-6.1/stm32mp1/dts/stm32mp15-txmp.dtsi
+++ b/recipes-kernel/linux/linux-karo-6.1/stm32mp1/dts/stm32mp15-txmp.dtsi
@@ -83,7 +83,6 @@
 	vmmc-supply = <&reg_3v3>;
 	no-1-8-v;
 	st,neg-edge;
-	st,use-ckin;
 	status = "okay";
 };
 


### PR DESCRIPTION
With this property, the SD card reader does not work. SD cards are not detected, and additionally, periodic kernel panics occur:

 INFO: task kworker/1:3:43 blocked for more than 122 seconds.
       Not tainted 6.1.28-karo+gbf4ad6fa4e53 #1
 "echo 0 > /proc/sys/kernel/hung_task_timeout_secs" disables this message.
 task:kworker/1:3     state:D stack:0     pid:43    ppid:2      flags:0x00000000
 Workqueue: events_freezable mmc_rescan
  __schedule from schedule+0x5c/0xb8
  schedule from schedule_timeout+0xc0/0xec
  schedule_timeout from wait_for_completion+0x64/0x134
  wait_for_completion from mmc_wait_for_req_done+0x7c/0xcc
  mmc_wait_for_req_done from mmc_wait_for_cmd+0x6c/0xac
  mmc_wait_for_cmd from sdio_reset+0x50/0x124
  sdio_reset from mmc_rescan_try_freq+0x140/0x194
  mmc_rescan_try_freq from mmc_rescan+0x16c/0x1e8
  mmc_rescan from process_one_work+0x1b4/0x3c0
  process_one_work from worker_thread+0x4c/0x4c8
  worker_thread from kthread+0xe0/0xfc
  kthread from ret_from_fork+0x14/0x2c
 Exception stack(0xde8ddfb0 to 0xde8ddff8)
 dfa0:                                     00000000 00000000 00000000 00000000
 dfc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
 dfe0: 00000000 00000000 00000000 00000000 00000013 00000000
 Kernel panic - not syncing: hung_task: blocked tasks

Not sure why that is exactly, but removing this property fixes it. Looking at mmci_probe_level_translator in drivers/mmc/host/mmci.c suggests that setting st,use-ckin without also setting the following properties doesn't make any sense:

- st,cmd-gpios
- st,ck-gpios
- st,ckin-gpios

See: https://github.com/torvalds/linux/blob/master/drivers/mmc/host/mmci.c#L2125-L2135

edit: I'm assuming this is actually the offending line: https://github.com/torvalds/linux/blob/master/drivers/mmc/host/mmci.c#L2123
See also the ST wiki: https://wiki.st.com/stm32mpu/wiki/SDMMC_device_tree_configuration
> By setting this property, the sdmmc_ckin pin from an external transceiver is used to sample the receive data.

So this property should only be set if an external transceiver is connected, right?